### PR TITLE
Update keyboard focus utility and add a11y story

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digitalpromise/design",
   "private": false,
-  "version": "4.10.0",
+  "version": "4.11.0",
   "type": "module",
   "main": "dist/index.js",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3008,11 +3008,11 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.0.28:
-    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+  tldts-core@7.0.29:
+    resolution: {integrity: sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==}
 
-  tldts@7.0.28:
-    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+  tldts@7.0.29:
+    resolution: {integrity: sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==}
     hasBin: true
 
   tough-cookie@6.0.1:
@@ -6165,15 +6165,15 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tldts-core@7.0.28: {}
+  tldts-core@7.0.29: {}
 
-  tldts@7.0.28:
+  tldts@7.0.29:
     dependencies:
-      tldts-core: 7.0.28
+      tldts-core: 7.0.29
 
   tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.0.28
+      tldts: 7.0.29
 
   tr46@6.0.0:
     dependencies:

--- a/src/a11y.stories.tsx
+++ b/src/a11y.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FormField, TextInput } from "./components/forms";
+import Button from "./components/button";
+
+const meta = {
+  title: "A11y/Keyboard Navigation",
+} satisfies Meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Focus: Story = {
+  render: () => (
+    <form
+      className="max-w-sm mx-auto flex flex-col gap-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+      }}
+    >
+      <a
+        className="kb-focus underline text-blue-4 font-medium"
+        href="#"
+        onClick={(e) => {
+          e.preventDefault();
+        }}
+      >
+        Need help? Contact Us.
+      </a>
+      <FormField
+        label="Email address"
+        Input={TextInput}
+        inputProps={{
+          type: "email",
+        }}
+      />
+      <Button type="submit" className="md:self-start">Submit</Button>
+    </form>
+  ),
+};
+
+export default meta;

--- a/src/main.css
+++ b/src/main.css
@@ -4,44 +4,18 @@
 @source "./index.js";
 @source "./forms.js";
 
-/* ==========================================
-   Keyboard Focus Indicator
-   ==========================================
-   Visible during keyboard navigation only.
-   Style: 4px Jade-4 (#14833F) line with 2px White (#FFF) outer stroke.
-   Placement: Outside stroke by default, inside stroke for space-constrained components.
-*/
-
-:root {
-  --focus-ring-color: #14833F;
-  --focus-ring-outer-color: #FFFFFF;
-  --focus-ring-width: 4px;
-  --focus-ring-outer-width: 2px;
-  --focus-ring-offset: 2px;
+@theme {
+  --color-focus: var(--color-jade-4);
 }
 
-/* Default focus ring - outside stroke */
-.focus-ring:focus-visible,
-*:focus-visible {
-  outline: none;
-  box-shadow:
-    0 0 0 var(--focus-ring-offset) var(--focus-ring-outer-color),
-    0 0 0 calc(var(--focus-ring-offset) + var(--focus-ring-width)) var(--focus-ring-color),
-    0 0 0 calc(var(--focus-ring-offset) + var(--focus-ring-width) + var(--focus-ring-outer-width)) var(--focus-ring-outer-color);
-}
-
-/* Inside focus ring - for space-constrained components (e.g., Top Nav Items) */
-.focus-ring-inside:focus-visible {
-  outline: none;
-  box-shadow:
-    inset 0 0 0 var(--focus-ring-outer-width) var(--focus-ring-outer-color),
-    inset 0 0 0 calc(var(--focus-ring-outer-width) + var(--focus-ring-width)) var(--focus-ring-color);
-}
-
-/* Reset focus for elements that need custom handling */
-.focus-ring-none:focus-visible {
-  outline: none;
-  box-shadow: none;
+/* Utility to apply an outline to elements that acquire keyboard focus */
+@utility kb-focus {
+  &:focus-visible {
+    outline-width: 2px;
+    outline-offset: 2px;
+    outline-color: var(--color-focus);
+    outline-style: solid;
+  }
 }
 
 @layer components {
@@ -135,31 +109,4 @@
 button[aria-label="Previous page"]:not(:disabled),
 button[aria-label="Next page"]:not(:disabled) {
   cursor: pointer;
-}
-
-/* Focus ring utilities */
-@utility focus-ring {
-  &:focus-visible {
-    outline: none;
-    box-shadow:
-      0 0 0 var(--focus-ring-offset) var(--focus-ring-outer-color),
-      0 0 0 calc(var(--focus-ring-offset) + var(--focus-ring-width)) var(--focus-ring-color),
-      0 0 0 calc(var(--focus-ring-offset) + var(--focus-ring-width) + var(--focus-ring-outer-width)) var(--focus-ring-outer-color);
-  }
-}
-
-@utility focus-ring-inside {
-  &:focus-visible {
-    outline: none;
-    box-shadow:
-      inset 0 0 0 var(--focus-ring-outer-width) var(--focus-ring-outer-color),
-      inset 0 0 0 calc(var(--focus-ring-outer-width) + var(--focus-ring-width)) var(--focus-ring-color);
-  }
-}
-
-@utility focus-ring-none {
-  &:focus-visible {
-    outline: none;
-    box-shadow: none;
-  }
 }


### PR DESCRIPTION
- Configure focus color with a theme variable and add custom utility
- Remove globally applied focus style
- Add a11y story to test focus handling for link, input, and button

TODO?: Add `:focus-visible` styles to Button component. Currently uses default user agent focus when navigating by keyboard. Related strategy could be adding an a11y hover variant that applies the hover styles on both `:hover` and `:focus-visible`.